### PR TITLE
Add constraint on MarkuSafe dependency

### DIFF
--- a/docker/jupyterlab-dash/environment.yml
+++ b/docker/jupyterlab-dash/environment.yml
@@ -7,6 +7,8 @@ dependencies:
   # main packages
   - jupyterlab>=3
   - ipywidgets>=7.6
+  # https://github.com/pallets/jinja/issues/1585
+  - markupsafe==2.1.0
   # kernel packages
   - xeus-python
   # plotting packages


### PR DESCRIPTION
Referring to current opened issues:

- ImportError: cannot import name 'soft_unicode' from 'markupsafe'
https://github.com/pallets/jinja/issues/1585