### PR TITLE
Update jupyterlab Dash kernel dependencies

### DIFF
--- a/docker/jupyterlab-dash/environment.yml
+++ b/docker/jupyterlab-dash/environment.yml
@@ -17,6 +17,8 @@ dependencies:
   - plotly
   - ipywidgets>=7.6
   - jupyter-dash
+  - ipykernel>=6
+  # https://github.com/plotly/jupyter-dash/issues/75
   - dash<2.0.0
   # extensions
   - jupyter-server-proxy


### PR DESCRIPTION
- [x] Enforce `ipykernel` version with `jupyter-dash` extension

**Issue with ipykernel version:**
- current: v5.5.4
- should be >= v6

`AttributeError` when trying to proxy Dash server via `JupyterDash.infer_jupyter_proxy_config()` on kernel method `.get_parent()`

Method introduced from [PR 661 (v6.*)](https://github.com/ipython/ipykernel/commits/main?after=dd0a9863e07c1d49f5aaf72c0c62670acee71b55+454&branch=main&qualified_name=refs%2Fheads%2Fmain)