### PR TITLE
Hotfix/CircleCI Docker image

### DIFF
--- a/docker/circleci/Dockerfile
+++ b/docker/circleci/Dockerfile
@@ -39,7 +39,7 @@ RUN pip install --upgrade pip && \
 
 # Install Noos CI/CD SDKs
 # -----------------------
-ARG NOOSINV_VERSION="0.0.10"
+ARG NOOSINV_VERSION="0.0.11"
 ARG NOOSTF_VERSION="0.0.6"
 RUN pip install noos-inv==$NOOSINV_VERSION noos-tf==$NOOSTF_VERSION
 


### PR DESCRIPTION
Upgrade noos-invoke provision librairy to v0.0.11