### PR TITLE
NPT-242/Hotfix JupyterLab dependencies

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -40,6 +40,6 @@ RUN rm -rf /tmp/* && \
 # --------------------
 ARG NODE_OPTIONS=--max-old-space-size=4096
 RUN jupyter lab clean && \
-    jupyter lab build --dev-build=False --name='Neptune'
+    jupyter lab build --dev-build=False --name='Noos'
 
 USER $NB_UID

--- a/docker/jupyterlab/environment.yml
+++ b/docker/jupyterlab/environment.yml
@@ -4,8 +4,9 @@ channels:
 dependencies:
   # metapackages
   - nomkl
-  # notebooks
-  - jupyterlab>=3
+  # z2jh setup
+  - jupyterlab>=3.0.0
+  - jupyterhub>=3.0.0
   # https://github.com/pallets/jinja/issues/1585
   - markupsafe>=2.1.0
   # https://github.com/jupyterlab/jupyterlab/issues/10228
@@ -15,12 +16,12 @@ dependencies:
   # plotting
   - matplotlib
   - plotly
-  - ipywidgets>=7.6
-  - jupyter-dash
-  - ipykernel>=6
   # https://github.com/plotly/jupyter-dash/issues/75
   - dash<2.0.0
+  - ipywidgets>=7.6
+  - ipykernel>=6
   # extensions
+  - jupyter-dash
   - jupyter-server-proxy
   - jupyterlab-git
   - jupyterlab-code-snippets


### PR DESCRIPTION
Upgrade Python dependencies in the JupyterLab docker image, to match requirements for JupyterHub v3+